### PR TITLE
TakePicture added picture_id also into the goal

### DIFF
--- a/action/TakePicture.action
+++ b/action/TakePicture.action
@@ -1,4 +1,5 @@
 # goal
+string picture_id
 ---
 # result
 bool picture_taken


### PR DESCRIPTION
I thought it might be useful to have it both in the goal and the response, in case Asil (or anyone else) only uses the response.